### PR TITLE
Delete existing Alaz-created tc filters before creating new ones

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,27 @@
+name: Tag
+on:
+  push:
+    tags: [v*.*.*]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          buildkitd-flags: --debug
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: | # build and push it with the tag created on the repo
+          committed_tag=${GITHUB_REF#refs/*/}
+          TAG=$(basename "${committed_tag}")
+          docker buildx build --platform linux/amd64 -t ghcr.io/${{ github.repository_owner }}/alaz:${TAG} --push .


### PR DESCRIPTION
While playing with the `tc` command, I discovered that our existing Alaz code was creating a new filter each time it started up without cleaning up the existing one. This is bad, so this PR adds code to delete the existing filters before creating the new ones.

(The filter is what runs the bpf code against ingress/egress on a network device so that we can inspect packets.)

Also, while working on getting throughput metrics for traffic to/from the Internet, I discovered that the way I was configuring the ingress filter was incorrect, and it actually wasn't doing anything. Turns out that the egress filter on its own was enough to provide intra-cluster throughput metrics, so for now I have just gotten rid of the logic that creates the ingress filter until I get it working properly, but that is not high priority right now.

I'm also adding CI to start properly creating versioned images here.