### PR TITLE
fix: reduce memory by not processing L7 metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,8 @@ func main() {
 	var ec *ebpf.EbpfCollector
 	if ebpfEnabled {
 		ec = ebpf.NewEbpfCollector(ctx)
-		go ec.Deploy()
+		// TODO(g-linville): uncomment this when we want to process L7
+		//go ec.Deploy()
 		go ec.DeployThroughput(throughputKubeEvents)
 
 		a := aggregator.NewAggregator(aggregatorKubeEvents, nil, ec.EbpfEvents(), exporter)


### PR DESCRIPTION
Wish I had thought of this sooner. This reduces the initial memory consumption of each Alaz pod from approx. 75Mi to approx. 15Mi.